### PR TITLE
Add method that also returns last known register state on VM exit.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ build = "build.rs"
 [dependencies]
 clippy = {version = "0.0.23", optional = true}
 errno = "0.1.4"
-ioctl = "0.3.3"
 libc = "0.2"
 log = "0.3"
 memmap = "0.2.1"


### PR DESCRIPTION
Since the run() method consumes the mutable self its is not possible
to use get_regs until result of run went out of scope. 
This makes it rather hard to emulate certain functionality.

Or maybe there is another way that I didn't see?

