### PR TITLE
Remove unneeded ioctl crate dependency.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ build = "build.rs"
 [dependencies]
 clippy = {version = "0.0.23", optional = true}
 errno = "0.1.4"
-ioctl = "0.3.3"
 libc = "0.2"
 log = "0.3"
 memmap = "0.2.1"

--- a/src/x86_64.rs
+++ b/src/x86_64.rs
@@ -161,7 +161,7 @@ impl ::std::default::Default for LapicState {
     }
 }
 #[repr(C)]
-#[derive(Copy)]
+#[derive(Copy, Debug)]
 pub struct Segment {
     pub base: u64,
     pub limit: u32,
@@ -188,7 +188,7 @@ impl ::std::default::Default for Segment {
     }
 }
 #[repr(C)]
-#[derive(Copy)]
+#[derive(Copy, Debug)]
 pub struct Dtable {
     pub base: u64,
     pub limit: u16,
@@ -205,7 +205,7 @@ impl ::std::default::Default for Dtable {
     }
 }
 #[repr(C)]
-#[derive(Copy)]
+#[derive(Copy, Debug)]
 pub struct Sregs {
     pub cs: Segment,
     pub ds: Segment,


### PR DESCRIPTION
All ioctl calls are in the C file so this dependency is not really needed. Stumbled over this due to cargo complaining it can't find the ioctl crate anymore (has been fully yanked). That error itself is probably a bug in Cargo but I didn't bother to investigate it.